### PR TITLE
fix(isValidTransactionAmount): update isValidTransactionAmount to support up to 2 decimal places

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,13 +164,13 @@ isValidCurrencyCode('XYZ'); // => false
 
 ### isValidTransactionAmount(amount: number): boolean
 
-Validates a transaction amount (up to 3 decimal places are allowed).
+Validates a transaction amount (up to 2 decimal places are allowed).
 
 ```ts
 import { isValidTransactionAmount } from 'valifino';
 
 /**
- * Validates a transaction amount (up to 3 decimal places are allowed).
+ * Validates a transaction amount (up to 2 decimal places are allowed).
  * @param {number} amount - The transaction amount to validate.
  * @returns True if the transaction amount is valid, false otherwise.
  */

--- a/src/validators/transactionAmount/validateTransactionAmount.ts
+++ b/src/validators/transactionAmount/validateTransactionAmount.ts
@@ -1,5 +1,5 @@
 /**
- * Validates a transaction amount (up to 3 decimal places are allowed).
+ * Validates a transaction amount (up to 2 decimal places are allowed).
  * @param {number} amount - The transaction amount to validate.
  * @returns True if the transaction amount is valid, false otherwise.
  */
@@ -10,5 +10,5 @@ export function isValidTransactionAmount(amount: number): boolean {
   }
 
   const decimalCount = (amount.toString().split('.')[1] || '').length;
-  return decimalCount <= 3;
+  return decimalCount <= 2;
 }

--- a/test/validators/transactionAmount/validateTransactionAmount.spec.ts
+++ b/test/validators/transactionAmount/validateTransactionAmount.spec.ts
@@ -4,13 +4,13 @@ describe('validateTransactionAmount', () => {
   describe('#isValidTransactionAmount', () => {
     it('should return true for valid transaction amounts', () => {
       expect(isValidTransactionAmount(100.0)).toBe(true); // 2 decimal places
-      expect(isValidTransactionAmount(49.999)).toBe(true); // 3 decimal places
       expect(isValidTransactionAmount(100)).toBe(true); // no decimal places
       expect(isValidTransactionAmount(49.9)).toBe(true); // 1 decimal place
     });
 
     it('should return false for invalid transaction amounts', () => {
       expect(isValidTransactionAmount(-100.0)).toBe(false); // negative amount
+      expect(isValidTransactionAmount(49.999)).toBe(false); // 3 decimal places
       expect(isValidTransactionAmount(49.9999)).toBe(false); // 4 decimal places
     });
 


### PR DESCRIPTION
### Description of change

Relates to https://github.com/aboutml/valifino/issues/37

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)
